### PR TITLE
Fix HTTP parser when body comes in several chunks

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 , "dependencies": {
     "underscore": "1.4.4"
    ,"agentkeepalive": "0.1.5"
+   ,"buffers": "0.1.1"
 }
 , "main": "./algoliasearch-node.js"
 }


### PR DESCRIPTION
The HTTP response can come in several chunks. In this case, the response will trigger 'data' several times before finally triggering 'end'. The code was assuming only a single 'data'.

I added a dependency on "buffers", because it made the code simpler. I can remove it if needed.
